### PR TITLE
feat: create new output script data class and method to identify NFT creation transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 /dist/
 /.coverage
 /htmlcov/
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ __pycache__/
 /dist/
 /.coverage
 /htmlcov/
-*.swp
+*~

--- a/hathorlib/base_transaction.py
+++ b/hathorlib/base_transaction.py
@@ -589,3 +589,16 @@ def output_value_to_bytes(number: int) -> bytes:
         return (-number).to_bytes(8, byteorder='big', signed=True)
     else:
         return number.to_bytes(4, byteorder='big', signed=True)  # `signed` makes no difference, but oh well
+
+
+def tx_or_block_from_bytes(data: bytes) -> BaseTransaction:
+    """ Creates the correct tx subclass from a sequence of bytes
+    """
+    # version field takes up the first 2 bytes
+    version = int.from_bytes(data[0:2], 'big')
+    try:
+        tx_version = TxVersion(version)
+        cls = tx_version.get_cls()
+        return cls.create_from_struct(data)
+    except ValueError:
+        raise StructError('Invalid bytes to create transaction subclass.')

--- a/hathorlib/base_transaction.py
+++ b/hathorlib/base_transaction.py
@@ -388,6 +388,11 @@ class BaseTransaction(ABC):
         """
         self.hash = self.calculate_hash()
 
+    @property
+    def is_nft_creation(self) -> bool:
+        """Returns True if it's an NFT creation transaction"""
+        return False
+
 
 class TxInput:
     _tx: BaseTransaction  # XXX: used for caching on hathor.transaction.Transaction.get_spent_tx

--- a/hathorlib/scripts.py
+++ b/hathorlib/scripts.py
@@ -355,6 +355,8 @@ class DataScript(BaseScript):
         """This class represents a data script usually used by NFT transactions.
         The script has a data field and ends with an OP_CHECKSIG so it can't be spent.
 
+        The script format is: <DATA_N> <OP_CHECKSIG>
+
         :param data: data string to be stored in the script
         :type data: string
         """

--- a/hathorlib/scripts.py
+++ b/hathorlib/scripts.py
@@ -16,7 +16,7 @@ from hathorlib.exceptions import ScriptError
 from hathorlib.utils import (
     decode_address,
     get_address_b58_from_public_key_hash,
-    get_address_b58_from_redeem_script_hash
+    get_address_b58_from_redeem_script_hash,
 )
 
 settings = HathorSettings()

--- a/hathorlib/scripts.py
+++ b/hathorlib/scripts.py
@@ -13,7 +13,11 @@ from typing import Any, Dict, List, Match, Optional, Pattern, Type, Union
 
 from hathorlib.conf import HathorSettings
 from hathorlib.exceptions import ScriptError
-from hathorlib.utils import get_address_b58_from_public_key_hash, get_address_b58_from_redeem_script_hash
+from hathorlib.utils import (
+    decode_address,
+    get_address_b58_from_public_key_hash,
+    get_address_b58_from_redeem_script_hash
+)
 
 settings = HathorSettings()
 

--- a/hathorlib/token_creation_tx.py
+++ b/hathorlib/token_creation_tx.py
@@ -175,6 +175,7 @@ class TokenCreationTransaction(Transaction):
         if clean_token_string(self.token_symbol) == clean_token_string(settings.HATHOR_TOKEN_SYMBOL):
             raise TransactionDataError('Invalid token symbol ({})'.format(self.token_symbol))
 
+    @property
     def is_nft_creation(self) -> bool:
         """Returns True if it's an NFT creation transaction"""
         # We will check the outputs to validate that we have an NFT standard creation

--- a/hathorlib/token_creation_tx.py
+++ b/hathorlib/token_creation_tx.py
@@ -196,7 +196,7 @@ class TokenCreationTransaction(Transaction):
 
         for output in self.outputs[1:]:
             parsed_output = P2PKH.parse_script(output.script)
-            if parsed_output is None or ((output.token_data & TxOutput.TOKEN_INDEX_MASK) not in [0, 1]):
+            if parsed_output is None or (output.get_token_index() not in [0, 1]):
                 # We allow only the first output to be a DataScript
                 # all other outputs must be a P2PKH of HTR or the created token
                 return False

--- a/hathorlib/token_creation_tx.py
+++ b/hathorlib/token_creation_tx.py
@@ -20,6 +20,7 @@ from typing import Tuple
 from hathorlib.base_transaction import TxInput, TxOutput
 from hathorlib.conf import HathorSettings
 from hathorlib.exceptions import TransactionDataError
+from hathorlib.scripts import P2PKH, DataScript
 from hathorlib.transaction import Transaction
 from hathorlib.utils import clean_token_string, int_to_bytes, unpack, unpack_len
 
@@ -173,6 +174,34 @@ class TokenCreationTransaction(Transaction):
             raise TransactionDataError('Invalid token name ({})'.format(self.token_name))
         if clean_token_string(self.token_symbol) == clean_token_string(settings.HATHOR_TOKEN_SYMBOL):
             raise TransactionDataError('Invalid token symbol ({})'.format(self.token_symbol))
+
+    def is_nft_creation(self) -> bool:
+        """Returns True if it's an NFT creation transaction"""
+        # We will check the outputs to validate that we have an NFT standard creation
+        # https://github.com/HathorNetwork/rfcs/blob/master/text/0032-nft-standard.md#transaction-standard
+        if len(self.outputs) < 2:
+            # NFT creation must have at least a DataScript output (the first one) and a Token P2PKH output
+            return False
+
+        first_output = self.outputs[0]
+        parsed_first_output = DataScript.parse_script(first_output.script)
+
+        if parsed_first_output is None:
+            # First output is not a DataScript output
+            return False
+
+        if first_output.value != 1 or first_output.token_data != 0:
+            # NFT creation DataScript output must have value 1 and must be of HTR
+            return False
+
+        for output in self.outputs[1:]:
+            parsed_output = P2PKH.parse_script(output.script)
+            if parsed_output is None or ((output.token_data & TxOutput.TOKEN_INDEX_MASK) not in [0, 1]):
+                # We allow only the first output to be a DataScript
+                # all other outputs must be a P2PKH of HTR or the created token
+                return False
+
+        return True
 
 
 def decode_string_utf8(encoded: bytes, key: str) -> str:

--- a/hathorlib/utils.py
+++ b/hathorlib/utils.py
@@ -188,10 +188,7 @@ def get_hash160(public_key_bytes: bytes) -> bytes:
 def is_nft_creation(tx: 'BaseTransaction') -> bool:
     """Returns True if the transaction is an NFT creation"""
     from hathorlib import TokenCreationTransaction
-    from hathorlib.base_transaction import TxVersion
-    if tx.version != TxVersion.TOKEN_CREATION_TRANSACTION:
+    if isinstance(tx, TokenCreationTransaction):
+        return tx.is_nft_creation()
+    else:
         return False
-
-    # Assert needed because of mypy strict
-    assert type(tx) == TokenCreationTransaction
-    return tx.is_nft_creation()

--- a/hathorlib/utils.py
+++ b/hathorlib/utils.py
@@ -183,12 +183,3 @@ def get_hash160(public_key_bytes: bytes) -> bytes:
     h = hashlib.new('ripemd160')
     h.update(key_hash.digest())
     return h.digest()
-
-
-def is_nft_creation(tx: 'BaseTransaction') -> bool:
-    """Returns True if the transaction is an NFT creation"""
-    from hathorlib import TokenCreationTransaction
-    if isinstance(tx, TokenCreationTransaction):
-        return tx.is_nft_creation()
-    else:
-        return False

--- a/hathorlib/utils.py
+++ b/hathorlib/utils.py
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 import hashlib
 import re
 import struct
-from typing import TYPE_CHECKING, Any, Tuple
+from typing import Any, Tuple
 
 import base58
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -15,9 +15,6 @@ from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
 from hathorlib.conf import HathorSettings
 from hathorlib.exceptions import InvalidAddress
-
-if TYPE_CHECKING:
-    from hathorlib import BaseTransaction
 
 settings = HathorSettings()
 

--- a/hathorlib/utils.py
+++ b/hathorlib/utils.py
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 import hashlib
 import re
 import struct
-from typing import Any, Tuple
+from typing import TYPE_CHECKING, Any, Tuple
 
 import base58
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -15,6 +15,9 @@ from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
 from hathorlib.conf import HathorSettings
 from hathorlib.exceptions import InvalidAddress
+
+if TYPE_CHECKING:
+    from hathorlib import BaseTransaction
 
 settings = HathorSettings()
 
@@ -180,3 +183,15 @@ def get_hash160(public_key_bytes: bytes) -> bytes:
     h = hashlib.new('ripemd160')
     h.update(key_hash.digest())
     return h.digest()
+
+
+def is_nft_creation(tx: 'BaseTransaction') -> bool:
+    """Returns True if the transaction is an NFT creation"""
+    from hathorlib import TokenCreationTransaction
+    from hathorlib.base_transaction import TxVersion
+    if tx.version != TxVersion.TOKEN_CREATION_TRANSACTION:
+        return False
+
+    # Assert needed because of mypy strict
+    assert type(tx) == TokenCreationTransaction
+    return tx.is_nft_creation()

--- a/tests/test_nft.py
+++ b/tests/test_nft.py
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 
 import unittest
 
-from hathorlib import TokenCreationTransaction, Transaction, TxOutput
+from hathorlib.base_transaction import TxOutput, tx_or_block_from_bytes
 from hathorlib.scripts import DataScript
 from hathorlib.utils import is_nft_creation
 
@@ -21,7 +21,7 @@ class HathorNFTTestCase(unittest.TestCase):
                              '97d97b28124ebbd0208d60d9f08780000000200001976a914e7c8133e7611a0ef57830f4321661ff9e5c42f'
                              '4188ac40200000218def41612cefe10200002d0403a9e39e8176b2e8ca6728f7c8393cea3403f4432c047e5'
                              'b28cb0470009ed2ab70b799729bcdbaa8edc064bd78fb258ea23fe6688272acad587445ab0000000c')
-        tx = Transaction.create_from_struct(data)
+        tx = tx_or_block_from_bytes(data)
         self.assertFalse(is_nft_creation(tx))
 
         # Create token tx
@@ -34,7 +34,7 @@ class HathorNFTTestCase(unittest.TestCase):
                               'a106a18ea5c1ce158d8488ac0106544f4b454e3104544b4e314032320a39bd7d606127f3ff02009ed2ab70b'
                               '799729bcdbaa8edc064bd78fb258ea23fe6688272acad587445ab00d9741624399388d196e5e409595e65a1'
                               '803764ee078f34ebb2bda63ff6a63a000104d8')
-        tx2 = TokenCreationTransaction.create_from_struct(data2)
+        tx2 = tx_or_block_from_bytes(data2)
         self.assertFalse(is_nft_creation(tx2))
 
         # NFT tx
@@ -46,11 +46,11 @@ class HathorNFTTestCase(unittest.TestCase):
                               '14e6b88ac01065465737474740354535440200000218def416127d5800200d9741624399388d196e5e40959'
                               '5e65a1803764ee078f34ebb2bda63ff6a63a001a2603c9a5947233dedb1160e9468e95563e76945ae58d829'
                               '118e17e668dc900000053')
-        tx3 = TokenCreationTransaction.create_from_struct(data3)
+        tx3 = tx_or_block_from_bytes(data3)
         self.assertTrue(is_nft_creation(tx3))
 
         # NFT custom tx with 2 data script outputs
-        tx4 = TokenCreationTransaction.create_from_struct(data3)
+        tx4 = tx_or_block_from_bytes(data3)
         # Add new data script output, creating a token creation tx with 2 script data outputs
         # This should be rejected as a standard NFT
         new_output = TxOutput(1, tx4.outputs[0].script, 0)
@@ -79,6 +79,6 @@ class HathorNFTTestCase(unittest.TestCase):
                              '14e6b88ac01065465737474740354535440200000218def416127d5800200d9741624399388d196e5e40959'
                              '5e65a1803764ee078f34ebb2bda63ff6a63a001a2603c9a5947233dedb1160e9468e95563e76945ae58d829'
                              '118e17e668dc900000053')
-        tx = TokenCreationTransaction.create_from_struct(data)
+        tx = tx_or_block_from_bytes(data)
         nft_script = DataScript.parse_script(tx.outputs[0].script)
         self.assertEqual(nft_script.data, 'TEST')

--- a/tests/test_nft.py
+++ b/tests/test_nft.py
@@ -9,7 +9,6 @@ import unittest
 
 from hathorlib.base_transaction import TxOutput, tx_or_block_from_bytes
 from hathorlib.scripts import DataScript
-from hathorlib.utils import is_nft_creation
 
 
 class HathorNFTTestCase(unittest.TestCase):
@@ -22,7 +21,7 @@ class HathorNFTTestCase(unittest.TestCase):
                              '4188ac40200000218def41612cefe10200002d0403a9e39e8176b2e8ca6728f7c8393cea3403f4432c047e5'
                              'b28cb0470009ed2ab70b799729bcdbaa8edc064bd78fb258ea23fe6688272acad587445ab0000000c')
         tx = tx_or_block_from_bytes(data)
-        self.assertFalse(is_nft_creation(tx))
+        self.assertFalse(tx.is_nft_creation)
 
         # Create token tx
         data2 = bytes.fromhex('0002010400b25b5385d9bbe80018a98884fdb2d63de3404c23e1b6695df34c103755b56900006a473045022'
@@ -35,7 +34,7 @@ class HathorNFTTestCase(unittest.TestCase):
                               '799729bcdbaa8edc064bd78fb258ea23fe6688272acad587445ab00d9741624399388d196e5e409595e65a1'
                               '803764ee078f34ebb2bda63ff6a63a000104d8')
         tx2 = tx_or_block_from_bytes(data2)
-        self.assertFalse(is_nft_creation(tx2))
+        self.assertFalse(tx2.is_nft_creation)
 
         # NFT tx
         data3 = bytes.fromhex('00020103000023117762f80fad7c28eea89e793036e8e5855038eee4deea02c53d7513e700006a473045022'
@@ -47,7 +46,7 @@ class HathorNFTTestCase(unittest.TestCase):
                               '5e65a1803764ee078f34ebb2bda63ff6a63a001a2603c9a5947233dedb1160e9468e95563e76945ae58d829'
                               '118e17e668dc900000053')
         tx3 = tx_or_block_from_bytes(data3)
-        self.assertTrue(is_nft_creation(tx3))
+        self.assertTrue(tx3.is_nft_creation)
 
         # NFT custom tx with 2 data script outputs
         tx4 = tx_or_block_from_bytes(data3)
@@ -55,7 +54,7 @@ class HathorNFTTestCase(unittest.TestCase):
         # This should be rejected as a standard NFT
         new_output = TxOutput(1, tx4.outputs[0].script, 0)
         tx4.outputs = [tx4.outputs[0], new_output] + tx4.outputs[1:]
-        self.assertFalse(is_nft_creation(tx4))
+        self.assertFalse(tx4.is_nft_creation)
 
     def test_script_data(self):
         # Create NFT script data test

--- a/tests/test_nft.py
+++ b/tests/test_nft.py
@@ -1,0 +1,84 @@
+"""
+Copyright (c) Hathor Labs and its affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+import unittest
+
+from hathorlib import TokenCreationTransaction, Transaction, TxOutput
+from hathorlib.scripts import DataScript
+from hathorlib.utils import is_nft_creation
+
+
+class HathorNFTTestCase(unittest.TestCase):
+    def test_is_nft(self):
+        # Normal tx
+        data = bytes.fromhex('000100010100c994a3f1b46ddeb7134f65cb18b1b11ca7e19d59875a704b2bb2f79f6700b60000694630440'
+                             '220066d379c43ee73c3704730a44d66a077fb2b1cee2b399cbcf87f34d2b2d84308022032e0a93662094c5d'
+                             'b4ed022708981717d06038924535257d181c2fa9f62a6ff9210310a7cd9cae728ddf8c7fef342f963b1cab1'
+                             '97d97b28124ebbd0208d60d9f08780000000200001976a914e7c8133e7611a0ef57830f4321661ff9e5c42f'
+                             '4188ac40200000218def41612cefe10200002d0403a9e39e8176b2e8ca6728f7c8393cea3403f4432c047e5'
+                             'b28cb0470009ed2ab70b799729bcdbaa8edc064bd78fb258ea23fe6688272acad587445ab0000000c')
+        tx = Transaction.create_from_struct(data)
+        self.assertFalse(is_nft_creation(tx))
+
+        # Create token tx
+        data2 = bytes.fromhex('0002010400b25b5385d9bbe80018a98884fdb2d63de3404c23e1b6695df34c103755b56900006a473045022'
+                              '100b05b56237bd425ceeedc1bed82660239ae5cba5790e58980072a6d7a0b00ad500220729c456675abbee1'
+                              '2b084ea841779ec26fe9d4ac4c3a6b2b004678ba697c66e72102c79cca85e51de1e3e85a232477d3be574aa'
+                              '8d83c975321ac1993143d18401f3c0000006401001976a914bdd06a2ec4f180e5f3f5752671a771544c3936'
+                              '4a88ac0000000181001976a914bdd06a2ec4f180e5f3f5752671a771544c39364a88ac0000000281001976a'
+                              '914bdd06a2ec4f180e5f3f5752671a771544c39364a88ac0000138700001976a914439d757c69635d48ddb2'
+                              'a106a18ea5c1ce158d8488ac0106544f4b454e3104544b4e314032320a39bd7d606127f3ff02009ed2ab70b'
+                              '799729bcdbaa8edc064bd78fb258ea23fe6688272acad587445ab00d9741624399388d196e5e409595e65a1'
+                              '803764ee078f34ebb2bda63ff6a63a000104d8')
+        tx2 = TokenCreationTransaction.create_from_struct(data2)
+        self.assertFalse(is_nft_creation(tx2))
+
+        # NFT tx
+        data3 = bytes.fromhex('00020103000023117762f80fad7c28eea89e793036e8e5855038eee4deea02c53d7513e700006a473045022'
+                              '100eab17bbadcd5297695847c7e81a9d9c8b7995b9816a8cb2db4f68721eef22d44022043e8b9498a557cd2'
+                              'f8f4e957241cc78fee4daf0e149de5b9529048ee1ca0140e2103e42187c715fbdd129ef40bf9c6c9c63a6e0'
+                              'd72d478d121fa23c6078fa5049457000000010000060454455354ac0000012c01001976a91495b3e7b7559a'
+                              '2b1ffa6c337fc6aeff74e963796588ac0000000281001976a914e7b6fadc93b5553781d73ac908134c0bbc5'
+                              '14e6b88ac01065465737474740354535440200000218def416127d5800200d9741624399388d196e5e40959'
+                              '5e65a1803764ee078f34ebb2bda63ff6a63a001a2603c9a5947233dedb1160e9468e95563e76945ae58d829'
+                              '118e17e668dc900000053')
+        tx3 = TokenCreationTransaction.create_from_struct(data3)
+        self.assertTrue(is_nft_creation(tx3))
+
+        # NFT custom tx with 2 data script outputs
+        tx4 = TokenCreationTransaction.create_from_struct(data3)
+        # Add new data script output, creating a token creation tx with 2 script data outputs
+        # This should be rejected as a standard NFT
+        new_output = TxOutput(1, tx4.outputs[0].script, 0)
+        tx4.outputs = [tx4.outputs[0], new_output] + tx4.outputs[1:]
+        self.assertFalse(is_nft_creation(tx4))
+
+    def test_script_data(self):
+        # Create NFT script data test
+        data = 'nft data test'
+        obj_data = DataScript(data)
+        human = obj_data.to_human_readable()
+        self.assertEqual(human['type'], 'Data')
+        self.assertEqual(human['data'], data)
+
+        script = obj_data.get_script()
+
+        parsed_obj = DataScript.parse_script(script)
+        self.assertEqual(parsed_obj.data, data)
+
+        # Parse output script from real NFT
+        data = bytes.fromhex('00020103000023117762f80fad7c28eea89e793036e8e5855038eee4deea02c53d7513e700006a473045022'
+                             '100eab17bbadcd5297695847c7e81a9d9c8b7995b9816a8cb2db4f68721eef22d44022043e8b9498a557cd2'
+                             'f8f4e957241cc78fee4daf0e149de5b9529048ee1ca0140e2103e42187c715fbdd129ef40bf9c6c9c63a6e0'
+                             'd72d478d121fa23c6078fa5049457000000010000060454455354ac0000012c01001976a91495b3e7b7559a'
+                             '2b1ffa6c337fc6aeff74e963796588ac0000000281001976a914e7b6fadc93b5553781d73ac908134c0bbc5'
+                             '14e6b88ac01065465737474740354535440200000218def416127d5800200d9741624399388d196e5e40959'
+                             '5e65a1803764ee078f34ebb2bda63ff6a63a001a2603c9a5947233dedb1160e9468e95563e76945ae58d829'
+                             '118e17e668dc900000053')
+        tx = TokenCreationTransaction.create_from_struct(data)
+        nft_script = DataScript.parse_script(tx.outputs[0].script)
+        self.assertEqual(nft_script.data, 'TEST')


### PR DESCRIPTION
## Questions

1. We have a method called `parse_address_script` on `scripts.py` file. This method was used by `P2PKH` and `MultiSig` classes but now it's being used also by `DataScript` class. At first I changed the name to `parse_script` but I was afraid that someone else might be using this lib already and I don't wanna break any compatibility, so I kept the same method name. Is it okay?