### PR TITLE
feat: new method to check if a transaction is standard

### DIFF
--- a/hathorlib/base_transaction.py
+++ b/hathorlib/base_transaction.py
@@ -396,8 +396,8 @@ class BaseTransaction(ABC):
         """Returns True if it's an NFT creation transaction"""
         return False
 
-    def is_standard(self,
-                    max_output_script_size=settings.MAX_OUTPUT_SCRIPT_SIZE, allow_non_standard_script=False) -> bool:
+    def is_standard(self, max_output_script_size: int = settings.MAX_OUTPUT_SCRIPT_SIZE,
+                    allow_non_standard_script: bool = False) -> bool:
         """Return True is the transaction is standard
         """
         is_nft_creation = self.is_nft_creation

--- a/hathorlib/base_transaction.py
+++ b/hathorlib/base_transaction.py
@@ -400,7 +400,7 @@ class BaseTransaction(ABC):
                     max_output_script_size=settings.MAX_OUTPUT_SCRIPT_SIZE, allow_non_standard_script=False) -> bool:
         """Return True is the transaction is standard
         """
-        is_nft_creation = tx.is_nft_creation
+        is_nft_creation = self.is_nft_creation
         # First we check if any output script exceeds the maximum script size allowed
         # Then we must check if all outputs are standard, and we allow a non
         # standard output only in nft creation transactions

--- a/hathorlib/conf/settings.py
+++ b/hathorlib/conf/settings.py
@@ -44,3 +44,6 @@ class HathorSettings(NamedTuple):
 
     # Amount in which tx min weight reaches the middle point between the minimum and maximum weight
     MIN_TX_WEIGHT_K: int = 100
+
+    # Maximum size of the tx output's script allowed for a tx to be standard
+    MAX_OUTPUT_SCRIPT_SIZE: int = 256

--- a/hathorlib/conf/settings.py
+++ b/hathorlib/conf/settings.py
@@ -46,4 +46,4 @@ class HathorSettings(NamedTuple):
     MIN_TX_WEIGHT_K: int = 100
 
     # Maximum size of the tx output's script allowed for a tx to be standard
-    MAX_OUTPUT_SCRIPT_SIZE: int = 256
+    PUSHTX_MAX_OUTPUT_SCRIPT_SIZE: int = 256

--- a/hathorlib/token_creation_tx.py
+++ b/hathorlib/token_creation_tx.py
@@ -20,7 +20,7 @@ from typing import Tuple
 from hathorlib.base_transaction import TxInput, TxOutput
 from hathorlib.conf import HathorSettings
 from hathorlib.exceptions import TransactionDataError
-from hathorlib.scripts import P2PKH, DataScript, MultiSig, parse_address_script
+from hathorlib.scripts import DataScript
 from hathorlib.transaction import Transaction
 from hathorlib.utils import clean_token_string, int_to_bytes, unpack, unpack_len
 

--- a/hathorlib/token_creation_tx.py
+++ b/hathorlib/token_creation_tx.py
@@ -175,9 +175,8 @@ class TokenCreationTransaction(Transaction):
         if clean_token_string(self.token_symbol) == clean_token_string(settings.HATHOR_TOKEN_SYMBOL):
             raise TransactionDataError('Invalid token symbol ({})'.format(self.token_symbol))
 
-    @property
-    def is_nft_creation(self) -> bool:
-        """Returns True if it's an NFT creation transaction"""
+    def is_nft_creation_standard(self) -> bool:
+        """Returns True if it's a standard NFT creation transaction"""
         # We will check the outputs to validate that we have an NFT standard creation
         # https://github.com/HathorNetwork/rfcs/blob/master/text/0032-nft-standard.md#transaction-standard
         if len(self.outputs) < 2:
@@ -195,14 +194,13 @@ class TokenCreationTransaction(Transaction):
             # NFT creation DataScript output must have value 1 and must be of HTR
             return False
 
-        for output in self.outputs[1:]:
-            parsed_output = parse_address_script(output.script)
+        if not first_output.is_standard_script(only_standard_script_type=False):
+            # Here we check that the script size is standard
+            return False
 
-            # We allow only the first output to be a DataScript
-            # all other outputs must be a P2PKH or MultiSig
-            allowed_types = (P2PKH, MultiSig)
-            if parsed_output is None or not isinstance(parsed_output, allowed_types):
-                # Invalid output type for an NFT creation tx
+        for output in self.outputs[1:]:
+            if not output.is_standard_script():
+                # Invalid output script for an NFT creation tx
                 return False
 
             if output.get_token_index() not in [0, 1]:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -131,7 +131,9 @@ class HathorCommonsTestCase(unittest.TestCase):
         self.assertFalse(tx2.is_standard())
         self.assertFalse(tx2.is_standard(std_max_output_script_size=settings.PUSHTX_MAX_OUTPUT_SCRIPT_SIZE + 1))
         self.assertTrue(
-            tx2.is_standard(std_max_output_script_size=settings.PUSHTX_MAX_OUTPUT_SCRIPT_SIZE + 1, only_standard_script_type=False)
+            tx2.is_standard(
+                std_max_output_script_size=settings.PUSHTX_MAX_OUTPUT_SCRIPT_SIZE + 1, only_standard_script_type=False
+            )
         )
 
         # Make first output non standard

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -125,18 +125,18 @@ class HathorCommonsTestCase(unittest.TestCase):
         self.assertTrue(tx.is_standard())
 
         # Change the first output to have script size bigger than allowed
-        tx.outputs[0].script = b'x' * (settings.MAX_OUTPUT_SCRIPT_SIZE + 1)
+        tx.outputs[0].script = b'x' * (settings.PUSHTX_MAX_OUTPUT_SCRIPT_SIZE + 1)
         tx_bytes_big = bytes(tx)
         tx2 = tx_or_block_from_bytes(tx_bytes_big)
         self.assertFalse(tx2.is_standard())
-        self.assertFalse(tx2.is_standard(max_output_script_size=settings.MAX_OUTPUT_SCRIPT_SIZE + 1))
+        self.assertFalse(tx2.is_standard(std_max_output_script_size=settings.PUSHTX_MAX_OUTPUT_SCRIPT_SIZE + 1))
         self.assertTrue(
-            tx2.is_standard(max_output_script_size=settings.MAX_OUTPUT_SCRIPT_SIZE + 1, allow_non_standard_script=True)
+            tx2.is_standard(std_max_output_script_size=settings.PUSHTX_MAX_OUTPUT_SCRIPT_SIZE + 1, only_standard_script_type=False)
         )
 
         # Make first output non standard
-        tx.outputs[0].script = b'x' * settings.MAX_OUTPUT_SCRIPT_SIZE
+        tx.outputs[0].script = b'x' * settings.PUSHTX_MAX_OUTPUT_SCRIPT_SIZE
         tx_bytes_non_standard = bytes(tx)
         tx3 = tx_or_block_from_bytes(tx_bytes_non_standard)
         self.assertFalse(tx3.is_standard())
-        self.assertTrue(tx3.is_standard(allow_non_standard_script=True))
+        self.assertTrue(tx3.is_standard(only_standard_script_type=False))

--- a/tests/test_nft.py
+++ b/tests/test_nft.py
@@ -21,7 +21,7 @@ class HathorNFTTestCase(unittest.TestCase):
                              '4188ac40200000218def41612cefe10200002d0403a9e39e8176b2e8ca6728f7c8393cea3403f4432c047e5'
                              'b28cb0470009ed2ab70b799729bcdbaa8edc064bd78fb258ea23fe6688272acad587445ab0000000c')
         tx = tx_or_block_from_bytes(data)
-        self.assertFalse(tx.is_nft_creation)
+        self.assertFalse(tx.is_nft_creation_standard())
         self.assertTrue(tx.is_standard())
 
         # Create token tx
@@ -35,7 +35,7 @@ class HathorNFTTestCase(unittest.TestCase):
                               '799729bcdbaa8edc064bd78fb258ea23fe6688272acad587445ab00d9741624399388d196e5e409595e65a1'
                               '803764ee078f34ebb2bda63ff6a63a000104d8')
         tx2 = tx_or_block_from_bytes(data2)
-        self.assertFalse(tx2.is_nft_creation)
+        self.assertFalse(tx2.is_nft_creation_standard())
         self.assertTrue(tx2.is_standard())
 
         # NFT tx
@@ -48,7 +48,7 @@ class HathorNFTTestCase(unittest.TestCase):
                               '5e65a1803764ee078f34ebb2bda63ff6a63a001a2603c9a5947233dedb1160e9468e95563e76945ae58d829'
                               '118e17e668dc900000053')
         tx3 = tx_or_block_from_bytes(data3)
-        self.assertTrue(tx3.is_nft_creation)
+        self.assertTrue(tx3.is_nft_creation_standard())
         self.assertTrue(tx3.is_standard())
 
         # NFT custom tx with 2 data script outputs
@@ -57,7 +57,7 @@ class HathorNFTTestCase(unittest.TestCase):
         # This should be rejected as a standard NFT
         new_output = TxOutput(1, tx4.outputs[0].script, 0)
         tx4.outputs = [tx4.outputs[0], new_output] + tx4.outputs[1:]
-        self.assertFalse(tx4.is_nft_creation)
+        self.assertFalse(tx4.is_nft_creation_standard())
         self.assertFalse(tx4.is_standard())
 
     def test_script_data(self):

--- a/tests/test_nft.py
+++ b/tests/test_nft.py
@@ -22,6 +22,7 @@ class HathorNFTTestCase(unittest.TestCase):
                              'b28cb0470009ed2ab70b799729bcdbaa8edc064bd78fb258ea23fe6688272acad587445ab0000000c')
         tx = tx_or_block_from_bytes(data)
         self.assertFalse(tx.is_nft_creation)
+        self.assertTrue(tx.is_standard())
 
         # Create token tx
         data2 = bytes.fromhex('0002010400b25b5385d9bbe80018a98884fdb2d63de3404c23e1b6695df34c103755b56900006a473045022'
@@ -35,6 +36,7 @@ class HathorNFTTestCase(unittest.TestCase):
                               '803764ee078f34ebb2bda63ff6a63a000104d8')
         tx2 = tx_or_block_from_bytes(data2)
         self.assertFalse(tx2.is_nft_creation)
+        self.assertTrue(tx2.is_standard())
 
         # NFT tx
         data3 = bytes.fromhex('00020103000023117762f80fad7c28eea89e793036e8e5855038eee4deea02c53d7513e700006a473045022'
@@ -47,6 +49,7 @@ class HathorNFTTestCase(unittest.TestCase):
                               '118e17e668dc900000053')
         tx3 = tx_or_block_from_bytes(data3)
         self.assertTrue(tx3.is_nft_creation)
+        self.assertTrue(tx3.is_standard())
 
         # NFT custom tx with 2 data script outputs
         tx4 = tx_or_block_from_bytes(data3)
@@ -55,6 +58,7 @@ class HathorNFTTestCase(unittest.TestCase):
         new_output = TxOutput(1, tx4.outputs[0].script, 0)
         tx4.outputs = [tx4.outputs[0], new_output] + tx4.outputs[1:]
         self.assertFalse(tx4.is_nft_creation)
+        self.assertFalse(tx4.is_standard())
 
     def test_script_data(self):
         # Create NFT script data test
@@ -81,3 +85,6 @@ class HathorNFTTestCase(unittest.TestCase):
         tx = tx_or_block_from_bytes(data)
         nft_script = DataScript.parse_script(tx.outputs[0].script)
         self.assertEqual(nft_script.data, 'TEST')
+
+        self.assertFalse(tx.outputs[0].is_standard_script())
+        self.assertTrue(tx.outputs[1].is_standard_script())


### PR DESCRIPTION
### Acceptance criteria

Create a new method that executes a whole check if a transaction is standard or not, as suggested by @msbrogli here (https://github.com/HathorNetwork/hathor-core/pull/311#discussion_r710667500).

### Motivation

We used to have 2 checks, (i) max output script size and (ii) output script being standard. Now we will add a new one, which is the nft creation transaction. Instead of having this conditionals being repeated, as we have today, we will create a method in the lib that run all the checks.