### PR TITLE
chore: replace flake9 with flake8

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,28 @@ hathorlib
 
 Hathor Network base library.
 
-Currently this is a placeholder, the actual library will be here soon.
+## Configuration
+
+To install dependencies, including optionals, run:
+
+    poetry install -E client
+
+## Running the tests
+
+To run the tests using poetry virtualenv:
+
+    poetry run make tests
+
+If are managing virtualenvs without poetry, make sure it's activated and run:
+
+    make tests
+
+## Running linters
+
+To run linters:
+
+    poetry run make tests
+
+Or without poetry venv:
+
+    make check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,14 @@ flake8 = "^4.0.1"
 [tool.poetry.extras]
 client = ["aiohttp", "structlog"]
 
+[tool.isort]
+combine_as_imports = true
+default_section = "THIRDPARTY"
+include_trailing_comma = true
+known_first_party = "hathorlib,tests"
+line_length = 119
+multi_line_output = 3
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,25 +40,14 @@ aiohttp = {version = ">=3.7.0", optional = true}
 cryptography = ">=3.3.1"
 
 [tool.poetry.dev-dependencies]
-flake9 = ">=3.8.0"
 isort = ">=5.7.0"
 mypy = ">=0.812"
 pytest = ">=6.2.0"
 pytest-cov = ">=2.11.0"
+flake8 = "^4.0.1"
 
 [tool.poetry.extras]
 client = ["aiohttp", "structlog"]
-
-[tool.flake8]
-max-line-length = 119
-
-[tool.isort]
-combine_as_imports = true
-default_section = "THIRDPARTY"
-include_trailing_comma = true
-known_first_party = "hathorlib,tests"
-line_length = 119
-multi_line_output = 3
 
 [build-system]
 requires = ["poetry-core"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[flake8]
+max-line-length = 119
+
+[isort]
+combine_as_imports = true
+default_section = THIRDPARTY
+include_trailing_comma = true
+known_first_party = hathorlib,tests
+line_length = 119
+multi_line_output = 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,2 @@
 [flake8]
 max-line-length = 119
-
-[isort]
-combine_as_imports = true
-default_section = THIRDPARTY
-include_trailing_comma = true
-known_first_party = hathorlib,tests
-line_length = 119
-multi_line_output = 3


### PR DESCRIPTION
### Acceptance Criteria
- We should use flake8 instead of flake9

### Motivation
[flake9](https://pypi.org/project/flake9/) is just a fork of flake8 to allow configuration in `pyproject.yaml`. However they haven't released a new version for almost 2 years now, while flake8 has released some.

It seems better to use flake8 even if we need to have an additional `setup.cfg` file, instead of using flake9 which seems to be not well maintaned.