### PR TITLE
chore: bump cryptography to 38.0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ all: check tests
 tests_lib = ./tests/
 
 pytest_flags = -p no:warnings --cov-report=term --cov-report=html --cov=hathorlib
-mypy_tests_flags = --warn-unused-configs --disallow-incomplete-defs --no-implicit-optional --warn-redundant-casts --strict-equality --disallow-subclassing-any --warn-return-any --disallow-untyped-decorators
-mypy_sources_flags = --strict
+mypy_tests_flags = --warn-unused-configs --disallow-incomplete-defs --no-implicit-optional --warn-redundant-casts --strict-equality --disallow-subclassing-any --warn-return-any --disallow-untyped-decorators --show-error-code
+mypy_sources_flags = --strict --show-error-code
 
 .PHONY: tests
 tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ python = ">=3.6,<4.0"
 base58 = ">=2.1.0"
 structlog = {version = ">=20.0.0", optional = true}
 aiohttp = {version = ">=3.7.0", optional = true}
-cryptography = ">=3.3.1"
+cryptography = ">=38.0.3"
+pycoin = "^0.92.20220529"
 
 # TODO: We should migrate from asynctest to pytest-asyncio when we raise our minimum Python version to 3.7
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
### Acceptance Criteria

- Bump cryptography to [38.0.3](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#3803---2022-11-01), that includes OpenSSL 3.0.7, which resolves CVE-2022-3602 and CVE-2022-3786.

- Because OpenSSL 3 drops support for `ripemd160` hash, one of our functions that depended on it stopped working. Because of this, I had to add the lib `pycoin` and a fallback that uses its pure Python implementation of `ripemd160`.  The fallback is the same as we had already done in https://github.com/HathorNetwork/hathor-core/pull/435