### PR TITLE
feat: add nano contract class with serializer/deserializer methods

### DIFF
--- a/hathorlib/base_transaction.py
+++ b/hathorlib/base_transaction.py
@@ -67,6 +67,7 @@ class TxVersion(IntEnum):
     REGULAR_TRANSACTION = 1
     TOKEN_CREATION_TRANSACTION = 2
     MERGE_MINED_BLOCK = 3
+    NANO_CONTRACT = 4
 
     @classmethod
     def _missing_(cls, value: Any) -> 'TxVersion':
@@ -80,11 +81,13 @@ class TxVersion(IntEnum):
 
     def get_cls(self) -> Type['BaseTransaction']:
         from hathorlib import Block, TokenCreationTransaction, Transaction
+        from hathorlib.nanocontracts.nanocontract import NanoContract
 
         cls_map: Dict[TxVersion, Type[BaseTransaction]] = {
             TxVersion.REGULAR_BLOCK: Block,
             TxVersion.REGULAR_TRANSACTION: Transaction,
             TxVersion.TOKEN_CREATION_TRANSACTION: TokenCreationTransaction,
+            TxVersion.NANO_CONTRACT: NanoContract,
         }
 
         cls = cls_map.get(self)

--- a/hathorlib/nanocontracts/__init__.py
+++ b/hathorlib/nanocontracts/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2023 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from hathorlib.nanocontracts.nanocontract import NanoContract
+
+__all__ = [
+    'NanoContract',
+]

--- a/hathorlib/nanocontracts/nanocontract.py
+++ b/hathorlib/nanocontracts/nanocontract.py
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import struct
-from typing import List, NamedTuple, Optional, Tuple
+from typing import NamedTuple, Tuple
 
+from hathorlib.base_transaction import TxVersion
 from hathorlib.transaction import Transaction
-from hathorlib.base_transaction import TxInput, TxOutput, TxVersion
 from hathorlib.utils import int_to_bytes, unpack, unpack_len
-
 
 NC_VERSION = 1
 

--- a/hathorlib/nanocontracts/nanocontract.py
+++ b/hathorlib/nanocontracts/nanocontract.py
@@ -1,0 +1,127 @@
+# Copyright 2023 Hathor Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import struct
+from typing import List, NamedTuple, Optional, Tuple
+
+from hathorlib.transaction import Transaction
+from hathorlib.base_transaction import TxInput, TxOutput, TxVersion
+from hathorlib.utils import int_to_bytes, unpack, unpack_len
+
+
+NC_VERSION = 1
+
+
+class NCCallInfo(NamedTuple):
+    """This tuple carries the pieces of information serialized inside transactions."""
+    version: int
+    id: bytes
+    method: str
+    args_bytes: bytes
+    pubkey: bytes
+    signature: bytes
+
+
+class NanoContract(Transaction):
+    """NanoContract vertex to be placed on the DAG of transactions."""
+
+    MIN_NUM_INPUTS = 0
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        self.version = TxVersion.NANO_CONTRACT
+
+        # nc_id equals to the blueprint_id when a Nano Contract is being created.
+        # nc_id equals to the nanocontract_id when a method is being called.
+        self.nc_id: bytes = b''
+
+        # Name of the method to be called. When creating a new Nano Contract, it must be equal to 'initialize'.
+        self.nc_method: str = ''
+
+        # Serialized arguments to nc_method.
+        self.nc_args_bytes: bytes = b''
+
+        # Pubkey and signature of the transaction owner / caller.
+        self.nc_pubkey: bytes = b''
+        self.nc_signature: bytes = b''
+
+    ################################
+    # Methods for Transaction
+    ################################
+
+    def get_funds_fields_from_struct(self, buf: bytes) -> bytes:
+        buf = super().get_funds_fields_from_struct(buf)
+
+        call_info, buf = NanoContract.deserialize_method_call(buf)
+        self.nc_id = call_info.id
+        self.nc_method = call_info.method
+        self.nc_args_bytes = call_info.args_bytes
+        self.nc_pubkey = call_info.pubkey
+        self.nc_signature = call_info.signature
+
+        return buf
+
+    @classmethod
+    def deserialize_method_call(cls, buf: bytes) -> Tuple[NCCallInfo, bytes]:
+        """Deserialize method call information from a serialized transaction."""
+        (nc_version,), buf = unpack('!B', buf)
+        if nc_version != NC_VERSION:
+            raise ValueError('unknown nanocontract version: {}'.format(nc_version))
+
+        nc_id, buf = unpack_len(32, buf)
+        (nc_method_len,), buf = unpack('!B', buf)
+        nc_method, buf = unpack_len(nc_method_len, buf)
+        (nc_args_bytes_len,), buf = unpack('!H', buf)
+        nc_args_bytes, buf = unpack_len(nc_args_bytes_len, buf)
+        (nc_pubkey_len,), buf = unpack('!B', buf)
+        nc_pubkey, buf = unpack_len(nc_pubkey_len, buf)
+        (nc_signature_len,), buf = unpack('!B', buf)
+        nc_signature, buf = unpack_len(nc_signature_len, buf)
+
+        decoded_nc_method = nc_method.decode('ascii')
+
+        return NCCallInfo(
+            version=nc_version,
+            id=nc_id,
+            method=decoded_nc_method,
+            args_bytes=nc_args_bytes,
+            pubkey=nc_pubkey,
+            signature=nc_signature,
+        ), buf
+
+    def get_funds_struct(self) -> bytes:
+        struct_bytes = super().get_funds_struct()
+        struct_bytes += self.serialize_method_call()
+        return struct_bytes
+
+    def serialize_method_call(self, *, skip_signature: bool = False) -> bytes:
+        """Serialize the method call as part of a transaction serialization."""
+        encoded_method = self.nc_method.encode('ascii')
+
+        ret = []
+        ret.append(int_to_bytes(NC_VERSION, 1))
+        ret.append(self.nc_id)
+        ret.append(int_to_bytes(len(self.nc_method), 1))
+        ret.append(encoded_method)
+        ret.append(int_to_bytes(len(self.nc_args_bytes), 2))
+        ret.append(self.nc_args_bytes)
+        ret.append(int_to_bytes(len(self.nc_pubkey), 1))
+        ret.append(self.nc_pubkey)
+        if not skip_signature:
+            ret.append(int_to_bytes(len(self.nc_signature), 1))
+            ret.append(self.nc_signature)
+        else:
+            ret.append(int_to_bytes(0, 1))
+        return b''.join(ret)

--- a/tests/test_nanocontract.py
+++ b/tests/test_nanocontract.py
@@ -1,0 +1,39 @@
+# Copyright (c) Hathor Labs and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from hathorlib.nanocontracts.nanocontract import NanoContract
+
+
+class NCNanoContractTestCase(unittest.TestCase):
+    def _get_nc(self):
+        nc = NanoContract()
+        nc.weight = 1
+        nc.timestamp = 123456
+        nc.nc_id = b'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+        nc.nc_method = 'initialize'
+        # ['string', 1]
+        nc.nc_args_bytes = b'\x00\x06string\x00\x04\x00\x00\x00\x01'
+        nc.nc_pubkey = b'\x020\xc1K\xb8\xc4fO>\xb7\x96a\xdeN\x96\x92\xcd\x1c' \
+                       b'\xa8\xa3]\xfeZ\xf7}\x95\x99\xb0\x1cBE\xc8\x90'
+        nc.nc_signature = b'0F\x02!\x00\x9c\xfey\xb1C\x9eAJ\x9eU~\xe3\xaf\xfcQ'  \
+                          b'\xf6\xf0`g\x1b0\xb6\xca\x1b\xed\x83:N\xa0\x98\xd2'   \
+                          b'\xdf\x02!\x00\xbe\xf85\xf6O`\xfed`Ip\xe2a\xc4\x03vv' \
+                          b'\xec\x94\ny?\xde\x90\xc3\x12\x9c\xd8\xdd\xd8\xe5\r'
+        return nc
+
+    def test_serialization(self):
+        nc = self._get_nc()
+
+        nc_bytes = bytes(nc)
+        nc2 = NanoContract.create_from_struct(nc_bytes)
+        self.assertEqual(nc_bytes, bytes(nc2))
+
+        self.assertEqual(nc.nc_id, nc2.nc_id)
+        self.assertEqual(nc.nc_method, nc2.nc_method)
+        self.assertEqual(nc.nc_args_bytes, nc2.nc_args_bytes)
+        self.assertEqual(nc.nc_pubkey, nc2.nc_pubkey)
+        self.assertEqual(nc.nc_signature, nc2.nc_signature)


### PR DESCRIPTION
## Acceptance Criteria

- Create NanoContract class.
- Add methods to serialize and deserialize the nano contract object.
- Transaction mining service should be able to mine nano contract transactions with the methods in the class.