### PR TITLE
chore: drop Python 3.6~3.8 and add Python 3.10~3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,13 +18,12 @@ jobs:
     strategy:
       matrix:
         python:
-        - 3.6
-        - 3.7
-        - 3.8
-        - 3.9
+        - "3.9"
+        - "3.10"
+        - "3.11"
         os:
-        - ubuntu-latest
-        - macos-latest
+        - ubuntu-22.04
+        - macos-12
         # - windows-latest
     steps:
     - name: Checkout
@@ -34,9 +33,9 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install Poetry
-      run: pip -q --no-input install poetry
+      run: pipx install poetry
     - name: Install Poetry dependencies
-      run: poetry install -n -E client
+      run: poetry install -n --no-root -E client
     - name: Run linters
       run: poetry run make check
     - name: Run tests
@@ -44,4 +43,4 @@ jobs:
       continue-on-error: ${{ matrix.tier > 1 }}
     - name: Upload coverage
       uses: codecov/codecov-action@v1
-      if: matrix.python == 3.6 && matrix.os == 'ubuntu-latest'
+      if: matrix.python == 3.9 && startsWith(matrix.os, 'ubuntu')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,21 +33,20 @@ include = ["hathorlib/py.typed"]
 exclude = ["tests", "tests.*"]
 
 [tool.poetry.dependencies]
-python = ">=3.6,<4.0"
-base58 = ">=2.1.0"
-structlog = {version = ">=20.0.0", optional = true}
-aiohttp = {version = ">=3.7.0", optional = true}
-cryptography = ">=38.0.3"
-pycoin = "^0.92.20220529"
+python = ">=3.9,<4"
+base58 = "~2.1.1"
+structlog = {version = "~22.3.0", optional = true}
+aiohttp = {version = "~3.8.3", optional = true}
+cryptography = "~38.0.3"
+pycoin = "~0.92"
 
-# TODO: We should migrate from asynctest to pytest-asyncio when we raise our minimum Python version to 3.7
 [tool.poetry.dev-dependencies]
-isort = ">=5.7.0"
-mypy = ">=0.812"
-pytest = ">=6.2.0"
-pytest-cov = ">=2.11.0"
-flake8 = "^4.0.1"
-asynctest = "^0.13.0"
+isort = {version = "~5.10.1", extras = ["colors"]}
+mypy = {version = "^1.0.0", markers = "implementation_name == 'cpython'"}
+pytest = "~7.2.0"
+pytest-cov = "~4.0.0"
+flake8 = "~6.0.0"
+pytest-asyncio = "~0.21.0"
 
 [tool.poetry.extras]
 client = ["aiohttp", "structlog"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,16 +6,18 @@ LICENSE file in the root directory of this source tree.
 """
 
 import asyncio
+from unittest import TestCase
 from unittest.mock import MagicMock, Mock
 
-import asynctest  # type: ignore
+import pytest
 
 from hathorlib.client import HathorClient
 from hathorlib.exceptions import PushTxFailed
 from tests.test_util import AsyncMock
 
 
-class ClientTestCase(asynctest.TestCase):  # type: ignore
+@pytest.mark.asyncio
+class ClientTestCase(TestCase):
     def setUp(self):
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)


### PR DESCRIPTION
## Acceptance Criteria

- CI must pass
- support for Python 3.6, 3.7 and 3.8 is removed
- support for Python 3.9 does not change, it was and will continue to be supported
- support for Python 3.10 and 3.11 is added