### PR TITLE
chore: bump package to v0.5.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,9 @@ jobs:
         # - windows-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # https://github.com/actions/checkout/releases/tag/v3.6.0
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # https://github.com/actions/setup-python/releases/tag/v2
       with:
         python-version: ${{ matrix.python }}
     - name: Install Poetry
@@ -42,5 +42,5 @@ jobs:
       run: poetry run make tests
       continue-on-error: ${{ matrix.tier > 1 }}
     - name: Upload coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192 # https://github.com/codecov/codecov-action/releases/tag/v1
       if: matrix.python == 3.9 && startsWith(matrix.os, 'ubuntu')

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ all: check tests
 tests_lib = ./tests/
 
 pytest_flags = -p no:warnings --cov-report=term --cov-report=html --cov=hathorlib
-mypy_tests_flags = --warn-unused-configs --disallow-incomplete-defs --no-implicit-optional --warn-redundant-casts --strict-equality --disallow-subclassing-any --warn-return-any --disallow-untyped-decorators --show-error-code
-mypy_sources_flags = --strict --show-error-code
+mypy_tests_flags = --warn-unused-configs --disallow-incomplete-defs --no-implicit-optional --warn-redundant-casts --strict-equality --disallow-subclassing-any --warn-return-any --disallow-untyped-decorators --show-error-codes
+mypy_sources_flags = --strict --show-error-codes
 
 .PHONY: tests
 tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@
 
 [tool.poetry]
 name = "hathorlib"
-version = "0.4.0"
+version = "0.5.0"
 description = "Hathor Network base objects library"
 authors = ["Hathor Team <contact@hathor.network>"]
 license = "Apache-2.0"


### PR DESCRIPTION
### Acceptance Criteria

- Bump package version to v0.5.0
- Update GitHub Actions config to use commit hash instead of tag
- Update `actions/checkout` from v2 to the latest, as it was using a [deprecated Node version](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/)
- Fix mypy option name