### PR TITLE
feat(feature-activation): implement signal bits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,9 @@ jobs:
         # - windows-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # https://github.com/actions/checkout/releases/tag/v3.6.0
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # https://github.com/actions/setup-python/releases/tag/v2
       with:
         python-version: ${{ matrix.python }}
     - name: Install Poetry
@@ -42,5 +42,5 @@ jobs:
       run: poetry run make tests
       continue-on-error: ${{ matrix.tier > 1 }}
     - name: Upload coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192 # https://github.com/codecov/codecov-action/releases/tag/v1
       if: matrix.python == 3.9 && startsWith(matrix.os, 'ubuntu')

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ all: check tests
 tests_lib = ./tests/
 
 pytest_flags = -p no:warnings --cov-report=term --cov-report=html --cov=hathorlib
-mypy_tests_flags = --warn-unused-configs --disallow-incomplete-defs --no-implicit-optional --warn-redundant-casts --strict-equality --disallow-subclassing-any --warn-return-any --disallow-untyped-decorators --show-error-code
-mypy_sources_flags = --strict --show-error-code
+mypy_tests_flags = --warn-unused-configs --disallow-incomplete-defs --no-implicit-optional --warn-redundant-casts --strict-equality --disallow-subclassing-any --warn-return-any --disallow-untyped-decorators --show-error-codes
+mypy_sources_flags = --strict --show-error-codes
 
 .PHONY: tests
 tests:

--- a/hathorlib/block.py
+++ b/hathorlib/block.py
@@ -11,11 +11,11 @@ from typing import Dict
 from hathorlib.base_transaction import BaseTransaction, TxOutput
 from hathorlib.utils import int_to_bytes, unpack, unpack_len
 
-# Version (H), outputs len (B)
-_FUNDS_FORMAT_STRING = '!HB'
+# Signal bits (B), version (B), outputs len (B)
+_FUNDS_FORMAT_STRING = '!BBB'
 
-# Version (H), inputs len (B) and outputs len (B)
-_SIGHASH_ALL_FORMAT_STRING = '!HBB'
+# Signal bits (B), version (B), inputs len (B) and outputs len (B)
+_SIGHASH_ALL_FORMAT_STRING = '!BBBB'
 
 
 class Block(BaseTransaction):
@@ -61,7 +61,7 @@ class Block(BaseTransaction):
 
         :raises ValueError: when the sequence of bytes is incorect
         """
-        (self.version, outputs_len), buf = unpack(_FUNDS_FORMAT_STRING, buf)
+        (self.signal_bits, self.version, outputs_len), buf = unpack(_FUNDS_FORMAT_STRING, buf)
 
         for _ in range(outputs_len):
             txout, buf = TxOutput.create_from_bytes(buf)
@@ -91,7 +91,7 @@ class Block(BaseTransaction):
         :return: funds data serialization of the block
         :rtype: bytes
         """
-        struct_bytes = pack(_FUNDS_FORMAT_STRING, self.version, len(self.outputs))
+        struct_bytes = pack(_FUNDS_FORMAT_STRING, self.signal_bits, self.version, len(self.outputs))
 
         for tx_output in self.outputs:
             struct_bytes += bytes(tx_output)

--- a/hathorlib/token_creation_tx.py
+++ b/hathorlib/token_creation_tx.py
@@ -26,11 +26,11 @@ from hathorlib.utils import clean_token_string, int_to_bytes, unpack, unpack_len
 
 settings = HathorSettings()
 
-# Version (H), inputs len (B), outputs len (B)
-_FUNDS_FORMAT_STRING = '!HBB'
+# Signal bits (B), version (B), inputs len (B), outputs len (B)
+_FUNDS_FORMAT_STRING = '!BBBB'
 
-# Version (H), inputs len (B), outputs len (B)
-_SIGHASH_ALL_FORMAT_STRING = '!HBB'
+# Signal bist (B), version (B), inputs len (B), outputs len (B)
+_SIGHASH_ALL_FORMAT_STRING = '!BBBB'
 
 # used when (de)serializing token information
 # version 1 expects only token name and symbol
@@ -67,7 +67,7 @@ class TokenCreationTransaction(Transaction):
 
         :raises ValueError: when the sequence of bytes is incorect
         """
-        (self.version, inputs_len, outputs_len), buf = unpack(_FUNDS_FORMAT_STRING, buf)
+        (self.signal_bits, self.version, inputs_len, outputs_len), buf = unpack(_FUNDS_FORMAT_STRING, buf)
 
         for _ in range(inputs_len):
             txin, buf = TxInput.create_from_bytes(buf)
@@ -88,7 +88,13 @@ class TokenCreationTransaction(Transaction):
         :return: funds data serialization of the transaction
         :rtype: bytes
         """
-        struct_bytes = pack(_FUNDS_FORMAT_STRING, self.version, len(self.inputs), len(self.outputs))
+        struct_bytes = pack(
+            _FUNDS_FORMAT_STRING,
+            self.signal_bits,
+            self.version,
+            len(self.inputs),
+            len(self.outputs)
+        )
 
         tx_inputs = []
         for tx_input in self.inputs:
@@ -110,7 +116,13 @@ class TokenCreationTransaction(Transaction):
         :return: Serialization of the inputs, outputs and tokens
         :rtype: bytes
         """
-        struct_bytes = pack(_SIGHASH_ALL_FORMAT_STRING, self.version, len(self.inputs), len(self.outputs))
+        struct_bytes = pack(
+            _SIGHASH_ALL_FORMAT_STRING,
+            self.signal_bits,
+            self.version,
+            len(self.inputs),
+            len(self.outputs)
+        )
 
         tx_inputs = []
         for tx_input in self.inputs:

--- a/hathorlib/transaction.py
+++ b/hathorlib/transaction.py
@@ -17,11 +17,11 @@ from hathorlib.utils import unpack, unpack_len
 
 settings = HathorSettings()
 
-# Version (H), token uids len (B) and inputs len (B), outputs len (B).
-_FUNDS_FORMAT_STRING = '!HBBB'
+# Signal bits (B), version (B), token uids len (B) and inputs len (B), outputs len (B).
+_FUNDS_FORMAT_STRING = '!BBBBB'
 
-# Version (H), inputs len (B), and outputs len (B), token uids len (B).
-_SIGHASH_ALL_FORMAT_STRING = '!HBBB'
+# Signal bits (B), version (B), inputs len (B), and outputs len (B), token uids len (B).
+_SIGHASH_ALL_FORMAT_STRING = '!BBBBB'
 
 TokenInfo = namedtuple('TokenInfo', 'amount can_mint can_melt')
 
@@ -79,7 +79,10 @@ class Transaction(BaseTransaction):
 
         :raises ValueError: when the sequence of bytes is incorect
         """
-        (self.version, tokens_len, inputs_len, outputs_len), buf = unpack(_FUNDS_FORMAT_STRING, buf)
+        (self.signal_bits, self.version, tokens_len, inputs_len, outputs_len), buf = unpack(
+            _FUNDS_FORMAT_STRING,
+            buf
+        )
 
         for _ in range(tokens_len):
             token_uid, buf = unpack_len(TX_HASH_SIZE, buf)
@@ -101,7 +104,14 @@ class Transaction(BaseTransaction):
         :return: funds data serialization of the transaction
         :rtype: bytes
         """
-        struct_bytes = pack(_FUNDS_FORMAT_STRING, self.version, len(self.tokens), len(self.inputs), len(self.outputs))
+        struct_bytes = pack(
+            _FUNDS_FORMAT_STRING,
+            self.signal_bits,
+            self.version,
+            len(self.tokens),
+            len(self.inputs),
+            len(self.outputs)
+        )
 
         for token_uid in self.tokens:
             struct_bytes += token_uid
@@ -120,8 +130,16 @@ class Transaction(BaseTransaction):
         :return: Serialization of the inputs, outputs and tokens
         :rtype: bytes
         """
-        struct_bytes = bytearray(pack(_SIGHASH_ALL_FORMAT_STRING, self.version, len(self.tokens), len(self.inputs),
-                                 len(self.outputs)))
+        struct_bytes = bytearray(
+            pack(
+                _SIGHASH_ALL_FORMAT_STRING,
+                self.signal_bits,
+                self.version,
+                len(self.tokens),
+                len(self.inputs),
+                len(self.outputs)
+            )
+        )
 
         for token_uid in self.tokens:
             struct_bytes += token_uid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@
 
 [tool.poetry]
 name = "hathorlib"
-version = "0.4.0"
+version = "0.5.0"
 description = "Hathor Network base objects library"
 authors = ["Hathor Team <contact@hathor.network>"]
 license = "Apache-2.0"


### PR DESCRIPTION
### Acceptance Criteria

- Add `signal_bits` field to transaction models
- Bump package version to v0.5.0
- Update GitHub Actions config to use commit hash instead of tag
- Update `actions/checkout` from v2 to the latest, as it was using a [deprecated Node version](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/)
- Fix mypy option name

This PR was originally in https://github.com/HathorNetwork/python-hathorlib/pull/28 and https://github.com/HathorNetwork/python-hathorlib/pull/29, but was reopened to fix a release process mistake.