### PR TITLE
fix: parse release-candidate hathor-core versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install Poetry
-      run: pipx install poetry
+      run: pip install poetry
     - name: Install Poetry dependencies
       run: poetry install -n --no-root -E client
     - name: Run linters

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ check: flake8 isort-check mypy
 
 # formatting:
 
+.PHONY: fmt
+fmt: isort
+
 .PHONY: isort
 isort: $(py_sources) $(py_tests)
 	isort -ac $^


### PR DESCRIPTION
### Acceptance Criteria

The lib should be able to parse hathor-core versions that belong to a release-candidate.

For instance, `0.58.0-rc.1`.

This PR makes sure it can parse all kinds of versions that follow the semver convention.

**Additional change**

I had to change the Github Actions job to use `pip` instead of `pipx` to install Poetry, because `pipx` was apparently not using the right python version.

This is a section of the run that should be done with Python 3.10, showing that it was using Python 3.12 somehow.

![image](https://github.com/HathorNetwork/python-hathorlib/assets/5041650/6f4565da-5432-476f-bb7a-3cfa7c41cae9)

Because of this, things were breaking strangely. You can check https://github.com/HathorNetwork/python-hathorlib/actions/runs/7145463994 for the full logs.

Replacing `pipx` with just `pip` resolved this issue.