### PR TITLE
chore: bump pyproject to v0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@
 
 [tool.poetry]
 name = "hathorlib"
-version = "0.7.0"
+version = "0.8.0"
 description = "Hathor Network base objects library"
 authors = ["Hathor Team <contact@hathor.network>"]
 license = "Apache-2.0"


### PR DESCRIPTION
### Acceptance Criteria

- Bump project to v0.8.0

Release PRs:

- https://github.com/HathorNetwork/python-hathorlib/pull/52