### PR TITLE
fix: limit mining header to 64 bytes

### DIFF
--- a/hathorlib/base_transaction.py
+++ b/hathorlib/base_transaction.py
@@ -376,22 +376,14 @@ class BaseTransaction(ABC):
         funds_hash.update(self.get_funds_struct())
         return funds_hash.digest()
 
-    def get_graph_hash(self) -> bytes:
-        """Return the sha256 of the graph part of the transaction
+    def get_graph_and_headers_hash(self) -> bytes:
+        """Return the sha256 of the graph part of the transaction + its headers
 
-        :return: the hash of the funds data
+        :return: the hash of the graph and headers data
         :rtype: bytes
         """
-        graph_hash = hashlib.sha256()
-        graph_hash.update(self.get_graph_struct())
-        return graph_hash.digest()
-
-    def get_headers_hash(self) -> bytes:
-        """Return the sha256 of the headers of the transaction."""
-        if not self.headers:
-            return b''
-
         h = hashlib.sha256()
+        h.update(self.get_graph_struct())
         h.update(self.get_headers_struct())
         return h.digest()
 
@@ -401,7 +393,9 @@ class BaseTransaction(ABC):
         :return: transaction header without the nonce
         :rtype: bytes
         """
-        return self.get_funds_hash() + self.get_graph_hash() + self.get_headers_hash()
+        data = self.get_funds_hash() + self.get_graph_and_headers_hash()
+        assert len(data) == 64, 'the mining data should have a fixed size of 64 bytes'
+        return data
 
     def calculate_hash1(self) -> HASH:
         """Return the sha256 of the transaction without including the `nonce`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@
 
 [tool.poetry]
 name = "hathorlib"
-version = "0.8.0"
+version = "0.8.1"
 description = "Hathor Network base objects library"
 authors = ["Hathor Team <contact@hathor.network>"]
 license = "Apache-2.0"


### PR DESCRIPTION
### Motivation

The `get_mining_header_without_nonce()` method was updated with the introduction of vertex headers, by appending the header hash in the end of its data. This is incompatible with our miners, because they're are hardcoded expecting a value with exactly 64 bytes.

This PR moves the header data to be appended to the graph data before the hash is applied, making sure the total size is still 64 bytes.

### Acceptance Criteria

- Remove `get_headers_hash()`.
- Change `get_graph_hash()` to `get_graph_and_headers_hash()`.
- Bump version to `v0.8.1`.